### PR TITLE
Add var to set dictionary file

### DIFF
--- a/naive-hashcat.sh
+++ b/naive-hashcat.sh
@@ -4,6 +4,7 @@ HASH_FILE="${HASH_FILE:-hashcat-3.6.0/example0.hash}"
 POT_FILE="${POT_FILE:-hashcat.pot}"
 HASH_TYPE="${HASH_TYPE:-0}"
 # WEIGHT="${WEIGHT:-"medium"}" # light, medium, heavy
+DICT_FILE="${DICT_FILE:-dicts/rockyou.txt}"
 
 # check OSX
 if [ "$(uname)" == 'Darwin' ] ; then
@@ -34,19 +35,19 @@ fi
 # DICTIONARY ATTACK-----------------------------------------------------------------------
 # begin with a _very_ simple and naive dictionary attack. This is blazing fast and 
 # I've seen it crack ~20% of hashes
-"$HASHCAT" -m "$HASH_TYPE" -a 0 "$HASH_FILE" dicts/rockyou.txt --potfile-path "$POT_FILE"
+"$HASHCAT" -m "$HASH_TYPE" -a 0 "$HASH_FILE" $DICT_FILE --potfile-path "$POT_FILE"
 
 # DICTIONARY ATTACK WITH RULES------------------------------------------------------------
 # now lets move on to a rule based attack, d3ad0ne.rule is a great one to start with
-"$HASHCAT" -m "$HASH_TYPE" -a 0 "$HASH_FILE" dicts/rockyou.txt -r hashcat-3.6.0/rules/d3ad0ne.rule --potfile-path "$POT_FILE"
+"$HASHCAT" -m "$HASH_TYPE" -a 0 "$HASH_FILE" $DICT_FILE -r hashcat-3.6.0/rules/d3ad0ne.rule --potfile-path "$POT_FILE"
 
 # rockyou is pretty good, and not too slow
-"$HASHCAT" -m "$HASH_TYPE" -a 0 "$HASH_FILE" dicts/rockyou.txt -r hashcat-3.6.0/rules/rockyou-30000.rule --potfile-path "$POT_FILE"
+"$HASHCAT" -m "$HASH_TYPE" -a 0 "$HASH_FILE" $DICT_FILE -r hashcat-3.6.0/rules/rockyou-30000.rule --potfile-path "$POT_FILE"
 
 
 # MEDIUM
 # dive is a great rule file, but it takes a bit longer to run, so we will run it after d3ad0ne and rockyou
-"$HASHCAT" -m "$HASH_TYPE" -a 0 "$HASH_FILE" dicts/rockyou.txt -r hashcat-3.6.0/rules/dive.rule --potfile-path "$POT_FILE"
+"$HASHCAT" -m "$HASH_TYPE" -a 0 "$HASH_FILE" $DICT_FILE -r hashcat-3.6.0/rules/dive.rule --potfile-path "$POT_FILE"
 
 # HEAVY
 # MASK ATTACK (BRUTE-FORCE)---------------------------------------------------------------
@@ -54,4 +55,4 @@ fi
 
 # COMBINATION ATTACK---------------------------------------------------------------------- 
 # this one can take 12+ hours, don't use it by default
-# "$HASHCAT" -m "$HASH_TYPE" -a 1 "$HASH_FILE" dicts/rockyou.txt dicts/rockyou.txt --potfile-path "POT_FILE" 
+# "$HASHCAT" -m "$HASH_TYPE" -a 1 "$HASH_FILE" $DICT_FILE $DICT_FILE --potfile-path "POT_FILE" 


### PR DESCRIPTION
Just a simple addition to make the tool point to a different dictionary file. Defaults to the original source: `dicts/rockyou.txt`.

Usage:
```
DICT_FILE=./another-wordlist.txt ./naive-hashcat.sh
```